### PR TITLE
MySQLのバージョンを5.7から8.0に変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
 # MySQLを動かすコンテナ
 # ----------------------------------
  db:
-   # Docker HubからMySQL5.7の公式イメージをダウンロードしてくる指定
-   image: mysql:5.7
+   # Docker HubからMySQL8.0の公式イメージをダウンロードしてくる指定
+   image: mysql:8.0
    container_name: laravel_db
 
    # コンテナ内の環境変数を指定。環境変数を渡すとビルド時に設定してくれるDockerイメージがあるので、利用の際はDocker Hubのサイトで確認する


### PR DESCRIPTION
Dockerで使用しているMySQLのバージョンを5.7から8.0へ変更する。
本番環境はDockerではないので影響はない。